### PR TITLE
Added the -F flag to grep in case there are '[]' in the URL

### DIFF
--- a/bashpodder
+++ b/bashpodder
@@ -26,7 +26,7 @@ while read podcast
 	for url in $file
 		do
 		echo $url >> temp.log
-		if ! grep "$url" podcast.log > /dev/null
+		if ! grep -F "$url" podcast.log > /dev/null
 			then
 			wget -t 10 -U BashPodder -c -q -O $datadir/$(echo "$url" | awk -F'/' {'print $NF'} | awk -F'=' {'print $NF'} | awk -F'?' {'print $1'}) "$url"
 		fi

--- a/bashpodder
+++ b/bashpodder
@@ -28,7 +28,8 @@ while read podcast
 		echo $url >> temp.log
 		if ! grep -F "$url" podcast.log > /dev/null
 			then
-			wget -t 10 -U BashPodder -c -q -O $datadir/$(echo "$url" | awk -F'/' {'print $NF'} | awk -F'=' {'print $NF'} | awk -F'?' {'print $1'}) "$url"
+			destination=$datadir/$(echo "$url" | awk -F'/' {'print $NF'} | awk -F'=' {'print $NF'} | awk -F'?' {'print $1'})
+                        wget -t 10 -U BashPodder -c -q -O $destination "$url" || rm $destination
 		fi
 		done
 	done < bp.conf


### PR DESCRIPTION
I noticed filenames containing the symbols '[' or ']' would be downloaded again and again because grep parses the URLs as regular expression. Adding the -F flag special regular expression characters are treated as normal characters.
