### PR TITLE
Remove podcast.log errors on first run and fix xsltproc parsing for https feeds

### DIFF
--- a/bashpodder
+++ b/bashpodder
@@ -22,7 +22,7 @@ rm -f temp.log
 # Read the bp.conf file and wget any url not already in the podcast.log file:
 while read podcast
 	do
-	file=$(xsltproc parse_enclosure.xsl $podcast 2> /dev/null || wget -q $podcast -O - | tr '\r' '\n' | tr \' \" | sed -n 's/.*url="\([^"]*\)".*/\1/p')
+	file=$(wget -q $podcast -O - | xsltproc parse_enclosure.xsl - 2> /dev/null || wget -q $podcast -O - | tr '\r' '\n' | tr \' \" | sed -n 's/.*url="\([^"]*\)".*/\1/p')
 	for url in $file
 		do
 		echo $url >> temp.log

--- a/bashpodder
+++ b/bashpodder
@@ -26,7 +26,7 @@ while read podcast
 	for url in $file
 		do
 		echo $url >> temp.log
-		if ! grep -F "$url" podcast.log > /dev/null
+		if ( ! [ -f podcast.log ] ) || ( ! grep -F "$url" podcast.log > /dev/null )
 			then
 			destination=$datadir/$(echo "$url" | awk -F'/' {'print $NF'} | awk -F'=' {'print $NF'} | awk -F'?' {'print $1'})
                         wget -t 10 -U BashPodder -c -q -O $destination "$url" || rm $destination
@@ -34,7 +34,10 @@ while read podcast
 		done
 	done < bp.conf
 # Move dynamically created log file to permanent log file:
-cat podcast.log >> temp.log
+if [ -f podcast.log ]
+then
+    cat podcast.log >> temp.log
+fi
 sort temp.log | uniq > podcast.log
 rm temp.log
 # Create an m3u playlist:


### PR DESCRIPTION
These changes fix 2 problems:
* Remove the warnings that podcast.log can't be found when the script is run for the first time
* When the RSS feed has an https link, the xsltproc command was giving an error.  The example feeds are http but most feeds are https nowadays.  This seems to be a known issue in xsltproc:
https://gitlab.gnome.org/GNOME/libxslt/-/issues/28
It seemed like maybe a benign problem in the script because, even without xsltproc installed, it still falls back on the use of sed to parse the xml document.  Nevertheless, it can be processed with xsltproc by first downloading the xml document with wget, then calling xsltproc on it.  According to the above linked issue, that seems to be the correct approach, so I changed bashpodder to do that.
